### PR TITLE
Fix: Ensure custom Git functions do not conflict with system Git

### DIFF
--- a/.config/zsh/functions/git/dotfiles_current_branch.zsh
+++ b/.config/zsh/functions/git/dotfiles_current_branch.zsh
@@ -2,8 +2,8 @@
 # Asume que tienes un alias 'dotfiles' definido como:
 # alias dotfiles='git --git-dir=$HOME/.dotfiles --work-tree=$HOME'
 dotfiles_current_branch() {
-  if alias dotfiles &> /dev/null; then
-    dotfiles rev-parse --abbrev-ref HEAD 2>/dev/null
+  if alias command dotfiles &> /dev/null; then
+    command dotfiles rev-parse --abbrev-ref HEAD 2>/dev/null
   else
     echo "Error: El alias 'dotfiles' no está definido." >&2
     return 1

--- a/.config/zsh/functions/git/gcbp.zsh
+++ b/.config/zsh/functions/git/gcbp.zsh
@@ -26,6 +26,6 @@ gcbp() {
     return 1
   fi
 
-  git checkout -b "$new_branch_name" "$base_branch" && \
-  git push -u origin "$new_branch_name"
+  command git checkout -b "$new_branch_name" "$base_branch" && \
+  command git push -u origin "$new_branch_name"
 }

--- a/.config/zsh/functions/git/gdelb.zsh
+++ b/.config/zsh/functions/git/gdelb.zsh
@@ -37,6 +37,6 @@ gdelb() {
     return 0
   fi
 
-  git branch -D "$branch_name" && \
-  git push origin --delete "$branch_name"
+  command git branch -D "$branch_name" && \
+  command git push origin --delete "$branch_name"
 }

--- a/.config/zsh/functions/git/git_current_branch.zsh
+++ b/.config/zsh/functions/git/git_current_branch.zsh
@@ -1,4 +1,4 @@
 # ~/.config/zsh/functions/git/git_current_branch.zsh
 git_current_branch() {
-  git rev-parse --abbrev-ref HEAD 2>/dev/null
+  command git rev-parse --abbrev-ref HEAD 2>/dev/null
 }

--- a/.config/zsh/functions/git/git_dynamic_aliases.zsh
+++ b/.config/zsh/functions/git/git_dynamic_aliases.zsh
@@ -13,7 +13,7 @@ gpusho() {
   
   if [[ -n "$current_branch" ]]; then
     echo "Haciendo push de '$current_branch' y estableciendo upstream..."
-    git push -u origin "$current_branch"
+    command git push -u origin "$current_branch"
   else
     echo "Error: No estás en una rama de Git válida."
     return 1
@@ -30,10 +30,10 @@ dpusho() {
   fi
   
   if [[ -n "$current_branch" ]]; then
-    echo "Haciendo push de dotfiles '$current_branch' y estableciendo upstream..."
-    dotfiles push -u origin "$current_branch"
+    echo "Haciendo push de command dotfiles '$current_branch' y estableciendo upstream..."
+    command dotfiles push -u origin "$current_branch"
   else
-    echo "Error: No estás en una rama de dotfiles válida."
+    echo "Error: No estás en una rama de command dotfiles válida."
     return 1
   fi
 }
@@ -67,7 +67,7 @@ show_current_dotfiles_branch() {
   if [[ -n "$current_branch" ]]; then
     echo "Rama actual de dotfiles: $current_branch"
   else
-    echo "No estás en un repositorio de dotfiles válido o no hay rama activa."
+    echo "No estás en un repositorio de command dotfiles válido o no hay rama activa."
     return 1
   fi
 }

--- a/.config/zsh/functions/git/git_feature_finish.zsh
+++ b/.config/zsh/functions/git/git_feature_finish.zsh
@@ -11,21 +11,21 @@ git_feature_finish() {
   fi
 
   # Verificar si la rama develop existe
-  if ! git show-ref --verify --quiet "refs/heads/$develop_branch" && ! git show-ref --verify --quiet "refs/remotes/origin/$develop_branch"; then
+  if ! command git show-ref --verify --quiet "refs/heads/$develop_branch" && ! command git show-ref --verify --quiet "refs/remotes/origin/$develop_branch"; then
     echo "Advertencia: La rama '$develop_branch' no parece existir localmente ni en origin. Intentando continuar..."
   fi
 
   # Verificar si la rama feature existe
-  if ! git show-ref --verify --quiet "refs/heads/feature/$feature_name"; then
+  if ! command git show-ref --verify --quiet "refs/heads/feature/$feature_name"; then
     echo "Error: La rama 'feature/$feature_name' no existe localmente."
     return 1
   fi
 
-  git checkout "$develop_branch" && \
-  git pull origin "$develop_branch" && \
-  git merge --no-ff "feature/$feature_name" && \
-  git branch -d "feature/$feature_name" && \
-  git push origin "$develop_branch" # Opcional: push develop después de mergear
+  command git checkout "$develop_branch" && \
+  command git pull origin "$develop_branch" && \
+  command git merge --no-ff "feature/$feature_name" && \
+  command git branch -d "feature/$feature_name" && \
+  command git push origin "$develop_branch" # Opcional: push develop después de mergear
   # Opcional: Borrar rama remota si existe
-  # git push origin --delete "feature/$feature_name"
+  # command git push origin --delete "feature/$feature_name"
 }

--- a/.config/zsh/functions/git/git_feature_start.zsh
+++ b/.config/zsh/functions/git/git_feature_start.zsh
@@ -11,12 +11,12 @@ git_feature_start() {
   fi
 
   # Verificar si la rama develop existe
-  if ! git show-ref --verify --quiet "refs/heads/$develop_branch" && ! git show-ref --verify --quiet "refs/remotes/origin/$develop_branch"; then
+  if ! command git show-ref --verify --quiet "refs/heads/$develop_branch" && ! command git show-ref --verify --quiet "refs/remotes/origin/$develop_branch"; then
     echo "Advertencia: La rama '$develop_branch' no parece existir localmente ni en origin. Intentando continuar..."
     # Podrías querer hacer 'git checkout main' o la rama principal por defecto aquí como fallback.
   fi
 
-  git checkout "$develop_branch" && \
-  git pull origin "$develop_branch" && \
-  git checkout -b "feature/$feature_name" "$develop_branch"
+  command git checkout "$develop_branch" && \
+  command git pull origin "$develop_branch" && \
+  command git checkout -b "feature/$feature_name" "$develop_branch"
 }

--- a/.config/zsh/functions/git/gunwip.zsh
+++ b/.config/zsh/functions/git/gunwip.zsh
@@ -2,5 +2,5 @@
 # gunwip
 # Deshace el último commit, pero mantiene los cambios en el área de staging.
 gunwip() {
-  git reset --soft HEAD^
+  command git reset --soft HEAD^
 }

--- a/.config/zsh/functions/git/gup.zsh
+++ b/.config/zsh/functions/git/gup.zsh
@@ -12,7 +12,7 @@ gup() {
 
   if [[ -n "$current_branch" ]]; then
     echo "Actualizando rama '$current_branch' desde origin..."
-    git fetch origin "$current_branch" && git rebase "origin/$current_branch"
+    command git fetch origin "$current_branch" && command git rebase "origin/$current_branch"
   else
     echo "No estás en una rama de Git."
     return 1

--- a/.config/zsh/functions/git/gupm.zsh
+++ b/.config/zsh/functions/git/gupm.zsh
@@ -12,7 +12,7 @@ gupm() {
 
   if [[ -n "$current_branch" ]]; then
     echo "Actualizando rama '$current_branch' desde origin con merge..."
-    git fetch origin "$current_branch" && git merge "origin/$current_branch"
+    command git fetch origin "$current_branch" && command git merge "origin/$current_branch"
   else
     echo "No estás en una rama de Git."
     return 1

--- a/.config/zsh/functions/git/gwip.zsh
+++ b/.config/zsh/functions/git/gwip.zsh
@@ -2,5 +2,5 @@
 # gwip
 # Añade todos los cambios y hace un commit con el mensaje "WIP"
 gwip() {
-  git add -A && git commit -m "WIP"
+  command git add -A && command git commit -m "WIP"
 }


### PR DESCRIPTION
You reported that enabling custom Zsh functions related to Git was causing the system's `git` command to malfunction.

This commit addresses the issue by:
1. Verifying that a duplicate function directory (`.config/zsh/functions_others/git/`) was not present, which could have caused conflicts if sourced.
2. Modifying all Git-related Zsh functions within `.config/zsh/functions/git/` to use `command git` and `command dotfiles` (for the `dotfiles` alias which wraps a Git command). This ensures that the actual executables are called, bypassing any potentially conflicting Zsh aliases or functions.

These changes aim to make the custom Git functions more robust and prevent them from interfering with the standard Git operations on your system.