### PR TITLE
Fix: Correct errors in custom Git functions

### DIFF
--- a/.config/zsh/functions/git/dotfiles_current_branch.zsh
+++ b/.config/zsh/functions/git/dotfiles_current_branch.zsh
@@ -2,7 +2,7 @@
 # Asume que tienes un alias 'dotfiles' definido como:
 # alias dotfiles='git --git-dir=$HOME/.dotfiles --work-tree=$HOME'
 dotfiles_current_branch() {
-  if alias command dotfiles &> /dev/null; then
+  if alias dotfiles &> /dev/null; then
     command dotfiles rev-parse --abbrev-ref HEAD 2>/dev/null
   else
     echo "Error: El alias 'dotfiles' no está definido." >&2

--- a/.config/zsh/functions/git/git_dynamic_aliases.zsh
+++ b/.config/zsh/functions/git/git_dynamic_aliases.zsh
@@ -30,10 +30,10 @@ dpusho() {
   fi
   
   if [[ -n "$current_branch" ]]; then
-    echo "Haciendo push de command dotfiles '$current_branch' y estableciendo upstream..."
+    echo "Haciendo push de dotfiles '$current_branch' y estableciendo upstream..."
     command dotfiles push -u origin "$current_branch"
   else
-    echo "Error: No estás en una rama de command dotfiles válida."
+    echo "Error: No estás en una rama de dotfiles válida."
     return 1
   fi
 }
@@ -67,7 +67,7 @@ show_current_dotfiles_branch() {
   if [[ -n "$current_branch" ]]; then
     echo "Rama actual de dotfiles: $current_branch"
   else
-    echo "No estás en un repositorio de command dotfiles válido o no hay rama activa."
+    echo "No estás en un repositorio de dotfiles válido o no hay rama activa."
     return 1
   fi
 }


### PR DESCRIPTION
This commit corrects issues introduced in the previous commit (fix/git-function-conflicts) that aimed to make Git functions more robust. The specific problems addressed are:

1.  In `.config/zsh/functions/git/dotfiles_current_branch.zsh`:
    *   Corrected an erroneous alias check `if alias command dotfiles`
        to `if alias dotfiles`.

2.  In `.config/zsh/functions/git/git_dynamic_aliases.zsh`:
    *   Removed the word "command" which was incorrectly inserted into
        user-facing echo messages within the `dpusho` and
        `show_current_dotfiles_branch` functions.

Other changes from the previous commit, such as prepending `command git` to direct Git executable calls, remain in place to ensure robustness against alias conflicts.