### PR TITLE
feat(install): automatizar la configuración de pnpm

### DIFF
--- a/.local/bin/install_software.sh
+++ b/.local/bin/install_software.sh
@@ -193,6 +193,13 @@ fi
 # 6. Instalar paquetes de NPM (Común)
 # -----------------------------------
 if command -v pnpm &> /dev/null; then
+    echo "Configurando pnpm..."
+    # Redirigir la salida para evitar que el script se detenga si ya está configurado
+    pnpm setup > /dev/null 2>&1 || true
+    # Exportar las variables para que estén disponibles en esta misma sesión del script
+    export PNPM_HOME="$HOME/.local/share/pnpm"
+    export PATH="$PNPM_HOME:$PATH"
+
     echo "Instalando paquetes globales de NPM con pnpm..."
     pnpm install -g "${NPM_PACKAGES[@]}"
 else


### PR DESCRIPTION
Añade el comando `pnpm setup` al script de instalación para evitar errores cuando el directorio global de pnpm no existe.

- Se ejecuta `pnpm setup` antes de la instalación de paquetes globales.
- Se exportan `PNPM_HOME` y `PATH` para asegurar que los cambios tomen efecto inmediatamente en la sesión del script.
- Se utiliza `$HOME` en lugar de una ruta absoluta para que el script sea portable entre diferentes usuarios.